### PR TITLE
Replace uri with request_uri

### DIFF
--- a/cve.js
+++ b/cve.js
@@ -12,7 +12,7 @@
 function inspect(r) {
 	let allHeaders = "";
 	r.rawHeadersIn.forEach(header => allHeaders += `${(header.join('--'))}`);
-	return checkIOCStrings(r, `${r.uri}${allHeaders}`);
+	return checkIOCStrings(r, `${r.rawVariables.request_uri}${allHeaders}`);
 }
 
 /**


### PR DESCRIPTION
This commit uses `r.rawVariables.request_uri` instead of `r.uri` to take get params into account while scanning for malicious strings.

Closes #1 